### PR TITLE
ensures that jquery is loaded, so $.ajax and dom manipulation work

### DIFF
--- a/MSBookmarklet.js
+++ b/MSBookmarklet.js
@@ -1,4 +1,5 @@
 javascript: (function () {
+msbookmarklet = function() {
   $.ajax({
     url: window.location.origin + document.getElementById('ServicePath').innerHTML + '/GetPlayerOptions',
     type: 'POST',
@@ -110,4 +111,13 @@ javascript: (function () {
       location.href = "#open-modal";
     }
   })
+}
+if (!window.jQuery) {
+  var script = document.createElement("script");
+  script.onload = msbookmarklet;
+  script.src = "//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js";
+  document.head.appendChild(script);
+} else {
+  msbookmarklet();
+}
 })()


### PR DESCRIPTION
In case jquery is not already loaded in the page, this modification will add jquery from cdn to the page, then call the bookmarklet code with the onload from that script. Otherwise, just call the bookmarklet code as-is.

The indentation ends up being a little weird here, but I left it this way to minimize the whitespace changes (which would reindent just about the whole file).